### PR TITLE
Only store last 200 repositories in storage

### DIFF
--- a/lib/github-helper.js
+++ b/lib/github-helper.js
@@ -3,6 +3,9 @@
 const debug = require('debug')('GitHub');
 const fetch = require('node-fetch');
 
+const MAX_RETURN_ROWS_NEW = 200;
+const PAGE_SIZE = 100;
+
 class GitHubHelper {
   constructor(orgNames, authentication) {
     this.repos = [];
@@ -27,7 +30,15 @@ class GitHubHelper {
       queue.push(promise);
     });
 
-    return Promise.all(queue).then(() => this.repos);
+    return Promise.all(queue).then(() => {
+      debug('sorting repositories according to date..');
+      // Sort dates newest -> oldest.
+      this.repos.sort((a, b) => {
+        return new Date(b.created_at) - new Date(a.created_at);
+      });
+
+      return this.repos
+    });
   }
 
   /**
@@ -57,7 +68,7 @@ class GitHubHelper {
   fetchPagesRecursively(page, orgName, resolve, reject) {
     debug(`getting page ${page} for ${orgName}`);
 
-    const params = `per_page=100&page=${page}&sort=created`;
+    const params = `per_page=${PAGE_SIZE}&page=${page}&sort=created`;
     const fullUrl = `${this.orgUrl}/${orgName}/repos?${params}`;
     const options = {
       headers: {
@@ -89,7 +100,8 @@ class GitHubHelper {
         }));
         this.repos = this.repos.concat(strippedDownRepos);
 
-        const hasMoreRepos = repositories && repositories.length === 100;
+        // Get next page if there are more repos that are new and we don't have the max that we display yet.
+        const hasMoreRepos = repositories && newRepositories.length === PAGE_SIZE && PAGE_SIZE * (page + 1) < MAX_RETURN_ROWS_NEW;
         if (hasMoreRepos) {
           debug(`we need to get more for ${orgName}!`);
           return this.fetchPagesRecursively(++page, orgName, resolve, reject);

--- a/lib/github-helper.js
+++ b/lib/github-helper.js
@@ -101,7 +101,7 @@ class GitHubHelper {
         this.repos = this.repos.concat(strippedDownRepos);
 
         // Get next page if there are more repos that are new and we don't have the max that we display yet.
-        const hasMoreRepos = repositories && newRepositories.length === PAGE_SIZE && PAGE_SIZE * (page + 1) < MAX_RETURN_ROWS_NEW;
+        const hasMoreRepos = repositories && newRepositories.length === PAGE_SIZE && PAGE_SIZE * (page + 1) <= MAX_RETURN_ROWS_NEW;
         if (hasMoreRepos) {
           debug(`we need to get more for ${orgName}!`);
           return this.fetchPagesRecursively(++page, orgName, resolve, reject);

--- a/lib/github-helper.js
+++ b/lib/github-helper.js
@@ -37,7 +37,7 @@ class GitHubHelper {
         return new Date(b.created_at) - new Date(a.created_at);
       });
 
-      return this.repos
+      return this.repos;
     });
   }
 

--- a/lib/storage-handler.js
+++ b/lib/storage-handler.js
@@ -3,6 +3,8 @@
 const debug = require('debug')('Storage');
 const Storage = require('dom-storage');
 
+const MAX_RETURN_ROWS_NEW = 200;
+
 /**
  * Handler which manages the connection and saving the data.
  */
@@ -29,14 +31,14 @@ class StorageHandler {
 
       this.storage.setItem('LAST_REPO_UPDATE', lastCheck);
 
-      let existingRepositories = this.storage.getItem('REPOSITORIES') || [];
-      let allRepositories = existingRepositories.concat(newRepositories);
-      debug('sorting repositories according to date..');
-      allRepositories.sort((a, b) => {
-        return new Date(b.created_at) - new Date(a.created_at);
-      });
+      let allRepositories = newRepositories;
+      if(allRepositories.length < MAX_RETURN_ROWS_NEW) {
+        debug('adding existing repositories back');
+        let existingRepositories = this.storage.getItem('REPOSITORIES') || [];
+        allRepositories = allRepositories.concat(existingRepositories);
+      }
 
-      this.storage.setItem('REPOSITORIES', allRepositories);
+      this.storage.setItem('REPOSITORIES', allRepositories.slice(0, MAX_RETURN_ROWS_NEW));
 
       debug('finished saving latest differences..');
       resolve(newRepositories);

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,14 +5,10 @@ const storageHandler = new StorageHandler();
 
 const REPO_KEY = 'REPOSITORIES';
 const WIKI_KEY = 'WIKI_EDITS';
-const MAX_RETURN_ROWS_NEW = 200;
 
 /* GET home page. */
 router.get('/', (req, res, next) => {
-  const repos = storageHandler.getStorageItem(REPO_KEY).sort((a, b) => {
-    return new Date(b.created_at) - new Date(a.created_at);
-  }).slice(0, MAX_RETURN_ROWS_NEW);
-
+  const repos = storageHandler.getStorageItem(REPO_KEY);
   const wikiEdits = storageHandler.getStorageItem(WIKI_KEY);
 
   res.render('index', {


### PR DESCRIPTION
Optimizes repo fetching and storage to
 1. Don't fetch more than 200 repos per org
 2. Sort repos by creation date once after all organizations have been fetched
 3. Only append existing repos, if we don't have 200 new ones
 4. Only save 200 new repos