### PR TITLE
Remove inexistent mozillafa org

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -39,7 +39,6 @@
   "MozillaTN",
   "MozillaUK",
   "MozillaWiki",
-  "Mozillafa",
   "Mozpacers",
   "OpenNews",
   "firefox-devtools",


### PR DESCRIPTION
Removed 'Mozillafa' from the organizations list.