### PR TITLE
Remove MozillaDataScience from organizations

### DIFF
--- a/organizations.json
+++ b/organizations.json
@@ -18,7 +18,6 @@
   "MozillaCentroamerica",
   "MozillaChina",
   "MozillaDanmark",
-  "MozillaDataScience",
   "MozillaDE",
   "MozillaDevelopers",
   "MozillaFestival",


### PR DESCRIPTION
Removed 'MozillaDataScience' from the organizations list as it doesn't exist anymore